### PR TITLE
Fixes Multi batched requests

### DIFF
--- a/Source/Quadrat.xcodeproj/project.pbxproj
+++ b/Source/Quadrat.xcodeproj/project.pbxproj
@@ -150,7 +150,9 @@
 				476B70DB1A0EBBA500AFAC33 /* QuadratTouch */,
 				476B708A1A0EBAE700AFAC33 /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		476B708A1A0EBAE700AFAC33 /* Products */ = {
 			isa = PBXGroup;

--- a/Source/Shared/Endpoints/Multi.swift
+++ b/Source/Shared/Endpoints/Multi.swift
@@ -30,11 +30,10 @@ public class Multi: Endpoint {
             if let params = request.parameters {
                 path = path + "?" + makeQuery(params)
             }
-            path = encodeURIComponent(path)
           
             queries.append(path)
         }
-        let queryString = ",".join(queries)
+        let queryString = encodeURIComponent(",".join(queries))
         
         let request =
         Request(baseURL: firstTask.request.baseURL,

--- a/Source/Shared/Endpoints/Multi.swift
+++ b/Source/Shared/Endpoints/Multi.swift
@@ -38,9 +38,11 @@ public class Multi: Endpoint {
         let request =
         Request(baseURL: firstTask.request.baseURL,
             path: self.endpoint,
-            parameters: [Parameter.requests:queryString],
+            parameters: nil,
             sessionParameters: firstTask.request.sessionParameters,
-            HTTPMethod: "POST")
+            HTTPMethod: "POST",
+            preformattedQueryString: "requests=\(queryString)"
+        )
         
         let multiTask = DataTask(session: self.session!, request: request, completionHandler: completionHandler)
         return multiTask

--- a/Source/Shared/Endpoints/Multi.swift
+++ b/Source/Shared/Endpoints/Multi.swift
@@ -8,6 +8,9 @@
 
 import Foundation
 
+func encodeURIComponent(string: String) -> String {
+    return string.stringByAddingPercentEncodingWithAllowedCharacters(.alphanumericCharacterSet())!
+}
 
 public class Multi: Endpoint {
     override var endpoint   : String {
@@ -23,13 +26,13 @@ public class Multi: Endpoint {
         var queries = [String]()
         for task in tasks {
             let request = task.request
-            let path = "/" + request.path.stringByAddingPercentEncodingWithAllowedCharacters(.URLQueryAllowedCharacterSet())!
-            if request.parameters != nil {
-                let query = path + makeQuery(request.parameters!)
-                queries.append(query)
-            } else {
-                queries.append(path)
+            var path = "/" + request.path
+            if let params = request.parameters {
+                path = path + "?" + makeQuery(params)
             }
+            path = encodeURIComponent(path)
+          
+            queries.append(path)
         }
         let queryString = ",".join(queries)
         
@@ -47,8 +50,8 @@ public class Multi: Endpoint {
     func makeQuery(parameters: Parameters) -> String {
         var query = String()
         for (key,value) in parameters {
-            let encodedValue = value.stringByAddingPercentEncodingWithAllowedCharacters(.URLQueryAllowedCharacterSet())
-            query += key + "=" + encodedValue! + "&"
+            let encodedValue = encodeURIComponent(value)
+            query += key + "=" + encodedValue + "&"
         }
         query.removeAtIndex(query.endIndex.predecessor())
         return query

--- a/Source/Shared/Parameters.swift
+++ b/Source/Shared/Parameters.swift
@@ -177,13 +177,18 @@ public class Parameter {
         return result
     }
     
-    class func buildURL(baseURL: NSURL, parameters: Parameters) -> NSURL {
+    class func buildURL(baseURL: NSURL, parameters: Parameters, preformattedQueryString: String? = nil) -> NSURL {
         let components = NSURLComponents(URL: baseURL, resolvingAgainstBaseURL: false)!
         let query = URLQuery(parameters)
         if components.query != nil {
             components.query = components.query! + "&" + query
         } else {
             components.query = query
+        }
+        
+        if let preformatted = preformattedQueryString {
+            let delimiter = components.query != nil ? "&" : "?"
+            return NSURL(string: components.URL!.absoluteString! + delimiter + preformatted)!
         }
         return components.URL!
     }

--- a/Source/Shared/Request.swift
+++ b/Source/Shared/Request.swift
@@ -27,21 +27,26 @@ class Request {
     /** The timeout interval in seconds. */
     var timeoutInterval     : NSTimeInterval = 60
     
-    init(baseURL:NSURL, path: String, parameters: Parameters?, sessionParameters:Parameters, HTTPMethod: String) {
+    /** Optionally pass in a preformatted query string to append after all other params are added **/
+    var preformattedQueryString: String?
+    
+    init(baseURL:NSURL, path: String, parameters: Parameters?, sessionParameters:Parameters, HTTPMethod: String, preformattedQueryString: String? = nil) {
         self.baseURL = baseURL
         self.parameters = parameters
         self.sessionParameters = sessionParameters
         self.HTTPMethod = HTTPMethod
         self.path = path
+        self.preformattedQueryString = preformattedQueryString
     }
     
     func URLRequest() -> NSURLRequest {
+        // if multi,
         var allParameters = self.sessionParameters
         if parameters != nil {
             allParameters += parameters!
         }
         let URL = self.baseURL.URLByAppendingPathComponent(self.path)
-        let requestURL = Parameter.buildURL(URL, parameters: allParameters)
+        let requestURL = Parameter.buildURL(URL, parameters: allParameters, preformattedQueryString: preformattedQueryString)
         let request = NSMutableURLRequest(URL: requestURL)
         request.HTTPMethod = HTTPMethod
         return request


### PR DESCRIPTION
This one is merged off the existing open PR...sorry about that.

Multi requests were completely broken. Unfortunately, Apple's character sets don't exactly do what we're looking for here. Also, there was a missing delimiter between the subrequest path and query params ( the `?`) that needed to be fixed.

Since you're already using NSURLComponents when building all URLs, I needed to bypass it so we didn't get a double-encoding. The encoding done by NSURLComponents is fine for everything except url-encoding urls within a url, so I just left the option to pass in a preformatted queryparam string, which is used by Multi.