### PR TITLE
fix(timeout):take timeout interval into account

### DIFF
--- a/Source/Shared/Session.swift
+++ b/Source/Shared/Session.swift
@@ -120,6 +120,7 @@ public class Session {
         self.configuration = configuration
         self.completionQueue = completionQueue
         let URLConfiguration = NSURLSessionConfiguration.defaultSessionConfiguration()
+        URLConfiguration.timeoutIntervalForRequest = configuration.timeoutInterval
         let delegateQueue = NSOperationQueue()
         delegateQueue.maxConcurrentOperationCount = 1
         self.URLSession = NSURLSession(configuration: URLConfiguration, delegate: nil, delegateQueue: delegateQueue)


### PR DESCRIPTION
The timeout property from Configuration object was never read and used.