### PR TITLE
Expression implicitly coerced from 'String?' to Any

### DIFF
--- a/Source/Shared/OauthErrors.swift
+++ b/Source/Shared/OauthErrors.swift
@@ -25,8 +25,8 @@ extension NSError {
     
     /** Creates an error from string error returned by Foursquare server. */
     class func quadratOauthErrorForString(_ string: String) -> NSError {
-        var code: QuadratOauthErrorCode!
-        var description: String!
+        var code: QuadratOauthErrorCode
+        var description: String
         
         switch string {
             case "invalid_request":


### PR DESCRIPTION
Swift Compiler Warning is issued in OauthErrors.swift.

![2017-02-15 0 25 46](https://cloud.githubusercontent.com/assets/893643/22935674/99763ab4-f316-11e6-8dcd-bbc494ebe11b.png)


ref. http://stackoverflow.com/questions/40691184/expression-implicitly-coerced-from-string-to-any